### PR TITLE
feat(android): add granular permissions for accessing photo, video, and audio

### DIFF
--- a/demo-snippets/platforms/android/AndroidManifest.xml
+++ b/demo-snippets/platforms/android/AndroidManifest.xml
@@ -11,6 +11,9 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/packages/perms/blueprint.md
+++ b/packages/perms/blueprint.md
@@ -38,6 +38,8 @@ The current supported permissions are:
 | Camera             | `camera`            | ✔  | ✔       |
 | Microphone         | `microphone`        | ✔  | ✔       |
 | Photos             | `photo`             | ✔  | ✔       |
+| Videos             | `video`             | ❌ | ✔ (api >= 33)       |
+| Audio              | `audio`             | ❌ | ✔ (api >= 33)       |
 | Contacts           | `contacts`          | ✔  | ✔       |
 | Events             | `event`             | ✔  | ✔       |
 | Bluetooth          | `bluetooth`         | ✔  | ✔(api >= 31)      |

--- a/src/perms/index.android.ts
+++ b/src/perms/index.android.ts
@@ -28,6 +28,8 @@ const NativePermissionsTypes: PermissionsType[] = [
     'event',
     'storage',
     'photo',
+    'video',
+    'audio',
     'callPhone',
     'readSms',
     'receiveSms',
@@ -96,7 +98,22 @@ function getNativePermissions<T extends PermissionsType = PermissionsType>(permi
             return result;
         }
         case 'photo': {
-            return ['android.permission.WRITE_EXTERNAL_STORAGE'];
+            if (getAndroidSDK() >= ANDROID13) {
+                return ['android.permission.READ_MEDIA_IMAGES'];
+            }
+            return ['android.permission.READ_EXTERNAL_STORAGE'];
+        }
+        case 'video': {
+            if (getAndroidSDK() >= ANDROID13) {
+                return ['android.permission.READ_MEDIA_VIDEO'];
+            }
+            return ['android.permission.READ_EXTERNAL_STORAGE'];
+        }
+        case 'audio': {
+            if (getAndroidSDK() >= ANDROID13) {
+                return ['android.permission.READ_MEDIA_AUDIO'];
+            }
+            return ['android.permission.READ_EXTERNAL_STORAGE'];
         }
         case 'callPhone': {
             return ['android.permission.CALL_PHONE'];

--- a/src/perms/index.d.ts
+++ b/src/perms/index.d.ts
@@ -14,6 +14,8 @@ export type Permissions =
     | 'camera'
     | 'microphone'
     | 'photo'
+    | 'video'
+    | 'audio'
     | 'contacts'
     | 'event'
     | 'reminder'


### PR DESCRIPTION
New granular permissions when accessing media were introduced in Android 13 ([Android docs](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions)). This PR adds the new granular permissions for >= API 33 and falls back to using `android.permission.READ_EXTERNAL_STORAGE` for < API 33.

@farfromrefug  I noticed that the `photo` permission was using `WRITE_EXTERNAL_STORAGE` instead of `READ_EXTERNAL_STORAGE`, should the fallback for < API 33 use the `WRITE_EXTERNAL_STORAGE` or `READ_EXTERNAL_STORAGE` permission?

This is what the new permission dialog for accessing audio using the granular permissions looks like 👇 

<img width="393" alt="Screen Shot 2023-02-02 at 13 24 08" src="https://user-images.githubusercontent.com/20136906/216242236-c1da6eed-7e19-40cc-b12e-65a890d66229.png">

Compared to the previous dialog for accessing storage 👇

<img width="393" alt="Screen Shot 2023-02-02 at 13 26 24" src="https://user-images.githubusercontent.com/20136906/216242323-ddc8356e-f234-4b11-9808-503245a7fd34.png">

