### PR TITLE
export `shouldShowRequestPermissionRationale` for Android 13

### DIFF
--- a/src/perms/index.android.ts
+++ b/src/perms/index.android.ts
@@ -317,7 +317,7 @@ async function requestMultiplePermissions(permissions: string[]): Promise<{ [per
     });
 }
 
-function shouldShowRequestPermissionRationale(permission: string | string[]) {
+export function shouldShowRequestPermissionRationale(permission: string | string[]) {
     if (getAndroidSDK() < MARSHMALLOW) {
         return Promise.resolve(false);
     }

--- a/src/perms/index.d.ts
+++ b/src/perms/index.d.ts
@@ -77,3 +77,4 @@ export function request<T extends Partial<ObjectPermissions | ObjectPermissionsR
 export function request<T extends string>(permission: T): Promise<Result>;
 
 export function checkMultiple<T extends Partial<ObjectPermissionsRest>>(permissions: T): Promise<MultiResult>;
+export function shouldShowRequestPermissionRationale<T extends string>(permission: T): Promise<boolean>;

--- a/src/perms/index.ios.ts
+++ b/src/perms/index.ios.ts
@@ -795,3 +795,7 @@ export function checkMultiple<T extends Partial<ObjectIOSPermissionsRest>>(permi
         }, {} as MultipleResult)
     );
 }
+
+export function shouldShowRequestPermissionRationale(permission) {
+    return Promise.resolve(false);
+}


### PR DESCRIPTION
This simply exports the function so that it can be used directly in client apps.
Nothing was changed with the manner in which `shouldShowRequestPermissionRationale` is currently being used in the plugin. However, that usage does not seem to really match with the Android docs. It seems that when `shouldShowRequestPermissionRationale` returns true, the permission check returns GRANT_RESULTS.DENIED. This does not make it possible to distinguish between a truly denied permission and one that simply needs to show a rationale before requesting the permission.

As per Android docs*, the flow should be:
1. check for permission
2. check for `shouldShowRequestPermissionRationale`
3. request permission (after showing rationale if indicated by step 2)


* ref steps 4,5,6 in [Workflow for requesting permissions](https://developer.android.com/training/permissions/requesting#workflow_for_requesting_permissions)