### PR TITLE
fix(ios): Support Limited as a status for photo permissions

### DIFF
--- a/src/perms/index.ios.ts
+++ b/src/perms/index.ios.ts
@@ -304,6 +304,9 @@ export namespace PermissionsIOS {
                 photoStatus = PHPhotoLibrary.authorizationStatus();
             }
             switch (photoStatus) {
+                case PHAuthorizationStatus.Limited:
+                    status = Status.Limited;
+                    break;
                 case PHAuthorizationStatus.Authorized:
                     status = Status.Authorized;
                     break;


### PR DESCRIPTION
If the user selects the "Select Photos.." options on the permissions dialog, `Undetermined` is being returned rather than `Limited` for photo.

This resolves that by returning `Limited`.